### PR TITLE
Improvements

### DIFF
--- a/TelegramBotFramework.Core/DefaultModules/Admin.cs
+++ b/TelegramBotFramework.Core/DefaultModules/Admin.cs
@@ -86,7 +86,10 @@ namespace TelegramBotFramework.DefaultModules
                     target.IsBotAdmin = true;
                     return new CommandResponse($"{target.Name} is now a bot admin.");
                 }
-                return new CommandResponse(null);
+                if (target != null && target.Id == args.SourceUser.Id)
+                    return new CommandResponse("You can't add yourself!");
+                else
+                    return new CommandResponse("Unknown user or user is not cached!");
             }          
         }
 
@@ -99,7 +102,10 @@ namespace TelegramBotFramework.DefaultModules
                 target.IsBotAdmin = false;
                 return new CommandResponse($"{target.Name} is no longer a bot admin.");
             }
-            return new CommandResponse(null);
+            if (target != null && target.Id == args.SourceUser.Id)
+                return new CommandResponse("You can't remove yourself!");
+            else 
+                return new CommandResponse("Unknown user or user is not cached!");
         }
         [ChatCommand(Triggers = new[] { "users" }, DevOnly = true, DontSearchInline = true)]
         public CommandResponse GetUsersList(CommandEventArgs args)

--- a/TelegramBotFramework.Core/Helpers/UserHelpers.cs
+++ b/TelegramBotFramework.Core/Helpers/UserHelpers.cs
@@ -12,7 +12,7 @@ namespace TelegramBotFramework.Core.Helpers
 {
     public static class UserHelper
     {
-        public static TelegramBotUser GetTelegramUser(ITelegramBotDbContext db, int adminId, Update update = null, InlineQuery query = null, CallbackQuery cbQuery = null, bool logPoint = true)
+        public static TelegramBotUser GetTelegramUser(ITelegramBotDbContext db, long adminId, Update update = null, InlineQuery query = null, CallbackQuery cbQuery = null, bool logPoint = true)
         {           
             using(db)
             {
@@ -45,7 +45,7 @@ namespace TelegramBotFramework.Core.Helpers
 
         public static TelegramBotUser GetTarget(this ITelegramBotDbContext db, CommandEventArgs args)
         {
-            return  args.Message.GetTarget(args.Parameters, args.SourceUser, db);
+            return  args.Message.GetTarget(args.Parameters, db);
         }
     }
 }

--- a/TelegramBotFramework.Core/Interfaces/ITelegramBotOptions.cs
+++ b/TelegramBotFramework.Core/Interfaces/ITelegramBotOptions.cs
@@ -8,11 +8,14 @@ namespace TelegramBotFramework.Core.Interfaces
     {
         string Key { get; set; }
         string Alias { get; set; }
-        int AdminId { get; set; }
+        long AdminId { get; set; }
         bool ShouldApprooveNewUsers { get; set; }
         string PaymentToken { get; set; }
         string Directory { get; set; }
         string WebHookUrl { get; set; }
         bool InMemoryDb { get; set; }
+        bool FileLog { get; set; }
+        bool AddonModules { get; set; }
+        bool DefaultModules { get; set; }
     }
 }

--- a/TelegramBotFramework.Core/Logging/TelegramBotLogger.cs
+++ b/TelegramBotFramework.Core/Logging/TelegramBotLogger.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using TelegramBotFramework.Core.Interfaces;
 
 namespace TelegramBotFramework.Core.Logging
 {
@@ -10,11 +11,17 @@ namespace TelegramBotFramework.Core.Logging
     {
         public readonly string Path;
         private readonly Queue<LogQueueItem> _logQueue = new Queue<LogQueueItem>();
-        public TelegramBotLogger(string directory)
+        private ITelegramBotOptions _options;
+        public TelegramBotLogger(ITelegramBotOptions options, string directory)
         {
+            _options = options;
             Path = directory;
-            Directory.CreateDirectory(Path);
-            new Task(WatchQueue).Start();
+
+            if (_options.FileLog)
+            {
+                Directory.CreateDirectory(Path);
+                new Task(WatchQueue).Start();
+            }
         }
         public void Write(object msg, LogLevel level = LogLevel.Info, ConsoleColor? overrideColor = null, string fileName = "log.log")
         {
@@ -43,7 +50,8 @@ namespace TelegramBotFramework.Core.Logging
                         break;
                 }
             finalMessage += msg.ToString();
-            _logQueue.Enqueue(new LogQueueItem(System.IO.Path.Combine(Path, fileName), finalMessage));
+            if (_options.FileLog)
+                _logQueue.Enqueue(new LogQueueItem(System.IO.Path.Combine(Path, fileName), finalMessage));
 
             Console.ForegroundColor = color;
             Console.Write(finalMessage);

--- a/TelegramBotFramework.Core/Objects/DefaultBotOptions.cs
+++ b/TelegramBotFramework.Core/Objects/DefaultBotOptions.cs
@@ -9,7 +9,7 @@ namespace TelegramBotFramework.Core.Objects
 {
     public class DefaultBotOptions : ITelegramBotOptions
     {
-        public DefaultBotOptions(string key, int adminId)
+        public DefaultBotOptions(string key, long adminId)
         {
             Key = key ?? throw new ArgumentNullException(nameof(key));
             AdminId = adminId;
@@ -17,11 +17,23 @@ namespace TelegramBotFramework.Core.Objects
 
         public string Key {get;set;}
         public string Alias { get; set; } = "TelegramBot";
-        public int AdminId {get;set;}
+        public long AdminId {get;set;}
         public bool ShouldApprooveNewUsers { get; set; } = false;
         public string PaymentToken {get;set;}
         public string Directory { get; set; } = "TelegramBot";
         public string WebHookUrl {get;set;}
         public bool InMemoryDb { get; set; } = false;
+        /// <summary>
+        /// Write all internal logs to a file instead of only printing them on the console screen
+        /// </summary>
+        public bool FileLog { get; set; } = true;
+        /// <summary>
+        /// Allows external modules and scans for them in the AddonModules directory
+        /// </summary>
+        public bool AddonModules { get; set; } = true;
+        /// <summary>
+        /// Enables default modules such as Admin and DefaultBotModule
+        /// </summary>
+        public bool DefaultModules { get; set; } = true;
     }
 }

--- a/TelegramBotFramework.Core/SQLiteDb/Extensions/TelegramBotDbExtensions.cs
+++ b/TelegramBotFramework.Core/SQLiteDb/Extensions/TelegramBotDbExtensions.cs
@@ -125,19 +125,17 @@ namespace TelegramBotFramework.Core.SQLiteDb.Extensions
         }
 
         #region Helpers
-        public static TelegramBotUser GetTarget(this Message message, string args, TelegramBotUser sourceUser, ITelegramBotDbContext db)
+        public static TelegramBotUser GetTarget(this Message message, string args, ITelegramBotDbContext db)
         {
-            if (message == null) return sourceUser;
+            if (message == null) return null;
             if (message?.ReplyToMessage != null)
             {
                 var m = message.ReplyToMessage;
                 var userid = m.ForwardFrom?.Id ?? m.From.Id;
-                return db.TelegramBotUsers.AsNoTracking().FirstOrDefault(x => x.UserId == userid) ?? sourceUser;
+                return db.TelegramBotUsers.AsNoTracking().FirstOrDefault(x => x.UserId == userid);
             }
             if (String.IsNullOrWhiteSpace(args))
-            {
-                return sourceUser;
-            }
+                return null;
             //check for a user mention
             var mention = message?.Entities.FirstOrDefault(x => x.Type == MessageEntityType.Mention);
             var textmention = message?.Entities.FirstOrDefault(x => x.Type == MessageEntityType.TextMention);
@@ -160,7 +158,7 @@ namespace TelegramBotFramework.Core.SQLiteDb.Extensions
                         x =>
                             String.Equals(x.UserId.ToString(), args, StringComparison.InvariantCultureIgnoreCase) ||
                             String.Equals(x.UserName, args.Replace("@", ""), StringComparison.InvariantCultureIgnoreCase));
-            return result ?? sourceUser;
+            return result;
         }
         #endregion
     }

--- a/TelegramBotFramework.Core/SQLiteDb/TelegramBotSetting.cs
+++ b/TelegramBotFramework.Core/SQLiteDb/TelegramBotSetting.cs
@@ -19,7 +19,7 @@ namespace TelegramBotFramework.Core.SQLiteDb
         /// <summary>
         /// The ID of the Telegram user who will be the main admin for the bot (typically, the person running the code)
         /// </summary>
-        public int TelegramDefaultAdminUserId { get; set; }
+        public long TelegramDefaultAdminUserId { get; set; }
         /// <summary>
         /// Your Telegram Bot API Token
         /// </summary>

--- a/TelegramBotFramework.Core/TelegramBotWrapper.cs
+++ b/TelegramBotFramework.Core/TelegramBotWrapper.cs
@@ -248,7 +248,7 @@ namespace TelegramBotFramework.Core
                         {
                             if (paramss[0].ParameterType.IsAssignableFrom(currentBot))
                             {
-                                Log.WriteLine($"Finded constructor, invoking it for loading {moduleAttributes.Name} at {this.GetType().FullName}");
+                                Log.WriteLine($"Found constructor, invoking it for loading {moduleAttributes.Name} at {this.GetType().FullName}");
 
                                 instance = c.Invoke(new object[] { this });
                             }
@@ -264,7 +264,7 @@ namespace TelegramBotFramework.Core
                     }
                     if (Modules.ContainsKey(moduleAttributes))
                     {
-                        Log.WriteLine($"{moduleAttributes.Name} has been already loaded. Rename it, if it is no dublicate");
+                        Log.WriteLine($"{moduleAttributes.Name} has been already loaded. Rename it, if it is no duplicate");
                         continue;
                     }
                     Modules.Add(moduleAttributes, instance);
@@ -287,7 +287,7 @@ namespace TelegramBotFramework.Core
                         var att = method.GetCustomAttributes<ChatCommand>().First();
                         if (Commands.ContainsKey(att))
                         {
-                            Log.WriteLine($"ChatCommand {method.Name}\n\t  with Trigger(s): {att.Triggers.Aggregate((a, b) => a + ", " + b)} not loaded, possible dublicate", overrideColor: ConsoleColor.Cyan);
+                            Log.WriteLine($"ChatCommand {method.Name}\n\t  with Trigger(s): {att.Triggers.Aggregate((a, b) => a + ", " + b)} not loaded, possible duplicate", overrideColor: ConsoleColor.Cyan);
                             continue;
                         }
                         Commands.Add(att, (ChatCommandMethod)Delegate.CreateDelegate(typeof(ChatCommandMethod), instance, method));
@@ -302,7 +302,7 @@ namespace TelegramBotFramework.Core
 
                         if (CallbackCommands.ContainsKey(att))
                         {
-                            Log.WriteLine($"Not loaded CallbackCommand {m.Name}\n\t Trigger: {att.Trigger}, possible dublicate", overrideColor: ConsoleColor.Cyan);
+                            Log.WriteLine($"Not loaded CallbackCommand {m.Name}\n\t Trigger: {att.Trigger}, possible duplicate", overrideColor: ConsoleColor.Cyan);
                             continue;
                         }
                         CallbackCommands.Add(att, (CallbackCommandMethod)Delegate.CreateDelegate(typeof(CallbackCommandMethod), instance, m));

--- a/TelegramBotFramework.Example/Program.cs
+++ b/TelegramBotFramework.Example/Program.cs
@@ -21,7 +21,7 @@ namespace TelegramBotFramework.Example
             var builder = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
             var configuration = builder.Build();
 
-            var opts = new DefaultBotOptions(configuration["key"], int.Parse(configuration["admin"]));
+            var opts = new DefaultBotOptions(configuration["key"], long.Parse(configuration["admin"]));
             opts.InMemoryDb = false;
 
             var bot = new SimpleTelegramBot(opts);


### PR DESCRIPTION
- Changed admin id from int to long (also in the example) since telegram user ids are not integers
- Instead of returning null when we can't find a user in RemoveBotAdmin and AddBotAdmin let's return "Unknown user or user is not cached!" (because we are checking the database for the target user) or "You can't add/remove yourself!"
- Changed "GetTarget" so it returns null instead of returning the source user (which made the null check pointless)
- Made file logging optional (added an option in DefaultBotOptions and the interface)
- Made loading default modules optional
- Made loading addon modules optional
- Fixed a few typos

_Disclaimer: I did not test all of the above changes (only the 1st, 2nd, and 3rd) but none of them should cause any exceptions_